### PR TITLE
Add rspec command configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,12 @@ Available commands:
 
 ## Extension Settings
 
-No settings are available.
+Available settings
+
+```
+// command prefix to execute rspec
+"quickRspec.commandPrefix": "bundle exec rspec",
+```
 
 ## Installation
 

--- a/extension.js
+++ b/extension.js
@@ -49,9 +49,10 @@ function activate(context) {
     let disposable2 = vscode.commands.registerCommand('extension.runSpec', function() {
         let terminal = getOrCreateTerminal("rspec");
         terminal.show(true);
+        let commandPrefix = vscode.workspace.getConfiguration('quickRspec').get('commandPrefix');
         let path = vscode.window.activeTextEditor.document.fileName.replace(vscode.workspace.rootPath + '/', '');
         let line = vscode.window.activeTextEditor.selection.active.line + 1;
-        terminal.sendText("bundle exec rspec " + path + ":" + line);
+        terminal.sendText(`${commandPrefix} ${path}:${line}`);
     });
 
     context.subscriptions.push(disposable2);

--- a/package.json
+++ b/package.json
@@ -37,7 +37,18 @@
                 "key": "ctrl+0",
                 "command": "extension.runSpec"
             }
-        ]
+        ],
+        "configuration": {
+            "type": "object",
+            "title": "Quick RSpec",
+            "properties": {
+                "quickRspec.commandPrefix": {
+                    "type": "string",
+                    "default": "bundle exec rspec",
+                    "description": "command prefix to execute rspec"
+                }
+            }
+        }
     },
     "scripts": {
         "postinstall": "node ./node_modules/vscode/bin/install",


### PR DESCRIPTION
This extension expects to run rspec as `bundle exec rspec ...`.

I want to run it by spring like `./bin/rspec ...`.

so I added command prefix configuration to change it.

![image](https://user-images.githubusercontent.com/23956/88351701-2cdfb880-cd92-11ea-8769-716476624ac3.png)
